### PR TITLE
Add request timeout to OpenRouter API calls

### DIFF
--- a/src/agent_island/player.py
+++ b/src/agent_island/player.py
@@ -79,10 +79,15 @@ class Player(ABC):
 
 
 class AIPlayer(Player):
-    def __init__(self, config: PlayerConfig, max_retries: int = 3):
+    def __init__(
+        self,
+        config: PlayerConfig,
+        max_retries: int = 3,
+        timeout_ms: int = 600_000,
+    ):
         self.config = config
         self.max_retries = max_retries
-        self.client = OpenRouter(api_key=config.api_key)
+        self.client = OpenRouter(api_key=config.api_key, timeout_ms=timeout_ms)
         self.memory: MemoryStrategy = create_strategy(config.memory_strategy)
 
     def free_response(


### PR DESCRIPTION
## Summary

- Add a 10-minute default `timeout_ms` to the `OpenRouter` client in `AIPlayer.__init__`, preventing indefinite hangs from dropped connections or server-side issues
- The existing retry logic in `_respond()` catches the resulting timeout exception and retries with exponential backoff

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Run a game end-to-end to verify normal requests complete within the timeout

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)