### PR TITLE
Add round_type to configure phase behavior per round

### DIFF
--- a/examples/game_config.toml
+++ b/examples/game_config.toml
@@ -27,7 +27,8 @@ simulate or predict the outcome of votes or future
 rounds.
 """
 
-# Skip memory consolidation in the final round
+# Final round: winner vote, no elimination or memory consolidation
 [[game.round_overrides]]
 round = 2
 phases = ["pitches", "votes"]
+round_type = "final"

--- a/examples/game_config_5.toml
+++ b/examples/game_config_5.toml
@@ -28,7 +28,8 @@ simulate or predict the outcome of votes or future
 rounds.
 """
 
-# Skip memory consolidation in the final round
+# Final round: winner vote, no elimination or memory consolidation
 [[game.round_overrides]]
 round = 4
 phases = ["pitches", "votes"]
+round_type = "final"

--- a/examples/game_config_no_logs.toml
+++ b/examples/game_config_no_logs.toml
@@ -27,7 +27,8 @@ simulate or predict the outcome of votes or future
 rounds.
 """
 
-# Skip memory consolidation in the final round
+# Final round: winner vote, no elimination or memory consolidation
 [[game.round_overrides]]
 round = 2
 phases = ["pitches", "votes"]
+round_type = "final"

--- a/examples/game_config_no_summ.toml
+++ b/examples/game_config_no_summ.toml
@@ -26,3 +26,9 @@ conversations, or events that did not occur. Do not
 simulate or predict the outcome of votes or future
 rounds.
 """
+
+# Final round: winner vote, no elimination
+[[game.round_overrides]]
+round = 2
+phases = ["pitches", "votes"]
+round_type = "final"

--- a/examples/quips_game_config.toml
+++ b/examples/quips_game_config.toml
@@ -31,7 +31,8 @@ simulate or predict the outcome of votes or future
 rounds.
 """
 
-# Skip memory consolidation in the final round; add quips after votes
+# Final round: winner vote with quips, no elimination or memory consolidation
 [[game.round_overrides]]
 round = 2
 phases = ["pitches", "votes", "opponent_quips"]
+round_type = "final"

--- a/examples/sidebars_extended_game_config.toml
+++ b/examples/sidebars_extended_game_config.toml
@@ -50,7 +50,8 @@ phases = ["sidebars", "pitches", "votes", "elimination", "consolidate_memory"]
 num_exchanges = 2
 messages_per_exchange = 4
 
-# Final round: no sidebars or memory consolidation
+# Final round: winner vote, no sidebars or memory consolidation
 [[game.round_overrides]]
 round = 4
 phases = ["pitches", "votes"]
+round_type = "final"

--- a/examples/sidebars_game_config.toml
+++ b/examples/sidebars_game_config.toml
@@ -40,7 +40,8 @@ rounds.
 num_exchanges = 1
 messages_per_exchange = 2
 
-# Final round: no sidebars or memory consolidation
+# Final round: winner vote, no sidebars or memory consolidation
 [[game.round_overrides]]
 round = 2
 phases = ["pitches", "votes"]
+round_type = "final"

--- a/src/agent_island/cli.py
+++ b/src/agent_island/cli.py
@@ -84,6 +84,8 @@ def main() -> None:
         logs_dir=game_data.get("logs_dir", LOGS_DIR) or None,
         rules_prompt=game_data["rules_prompt"],
         round_phase_overrides=game_data.get("round_phase_overrides", {}),
+        round_type=game_data.get("round_type", "elimination"),
+        round_type_overrides=game_data.get("round_type_overrides", {}),
         phase_config=game_data.get("phase_config", {}),
         round_phase_config_overrides=game_data.get("round_phase_config_overrides", {}),
         log_prefix=game_data.get("log_prefix", "gameplay"),

--- a/src/agent_island/engine.py
+++ b/src/agent_island/engine.py
@@ -26,6 +26,8 @@ class GameConfig:
         logs_dir: Directory to save logs (None to skip logging)
         rules_prompt: Prompt with the rules of the game
         round_phase_overrides: Per-round phase overrides keyed by round number
+        round_type: Default round type ("elimination" or "final")
+        round_type_overrides: Per-round round_type overrides keyed by round number
         phase_config: Default per-phase config keyed by phase name
         round_phase_config_overrides: Per-round phase config overrides
         log_prefix: Optional prefix for log filenames (default: "gameplay")
@@ -38,6 +40,8 @@ class GameConfig:
     rules_prompt: str
     logs_dir: str | None = field(default=None)
     round_phase_overrides: dict[int, list[str]] = field(default_factory=dict)
+    round_type: str = field(default="elimination")
+    round_type_overrides: dict[int, str] = field(default_factory=dict)
     phase_config: dict[str, dict] = field(default_factory=dict)
     round_phase_config_overrides: dict[int, dict[str, dict]] = field(
         default_factory=dict
@@ -146,6 +150,12 @@ class GameEngine:
             phases.append(fn)
         return phases
 
+    def _get_round_type(self, round_index: int) -> str:
+        """Get the round type for a given round (override or default)."""
+        return self.game_config.round_type_overrides.get(
+            round_index, self.game_config.round_type
+        )
+
     def _create_round_context(
         self,
         round_index: int,
@@ -178,6 +188,7 @@ class GameEngine:
         return RoundContext(
             round_index=round_index,
             final_round=final_round,
+            round_type=self._get_round_type(round_index),
             players=players,
             active_player_ids=active_player_ids,
             eliminated_player_ids=eliminated_player_ids,
@@ -217,7 +228,6 @@ class GameEngine:
         try:
             for round_index in range(1, num_rounds + 1):
                 final_round = round_index == num_rounds
-                outcome = "Winning" if final_round else "Eliminated"
 
                 self.logger.info(f"Round {round_index}")
 
@@ -241,8 +251,9 @@ class GameEngine:
                     self.logger.debug(
                         f"Vote tally: {round_context.votes.get('vote_tally')}"
                     )
-                    selected = round_context.votes.get("selected_player")
-                    self.logger.debug(f"{outcome} player: {selected}")
+                    self.logger.debug(
+                        f"Selected player: {round_context.votes.get('selected_player')}"
+                    )
 
                 # Sync active player IDs from the round context
                 # (the elimination phase may have modified it)
@@ -381,6 +392,11 @@ class GameEngine:
                     "round_phase_overrides": {
                         str(k): v
                         for k, v in self.game_config.round_phase_overrides.items()
+                    },
+                    "round_type": self.game_config.round_type,
+                    "round_type_overrides": {
+                        str(k): v
+                        for k, v in self.game_config.round_type_overrides.items()
                     },
                     "phase_config": self.game_config.phase_config,
                     "round_phase_config_overrides": {

--- a/src/agent_island/loaders.py
+++ b/src/agent_island/loaders.py
@@ -30,6 +30,11 @@ def load_game_config_from_toml(config_path: pathlib.Path) -> dict:
     game["round_phase_overrides"] = {
         entry["round"]: entry["phases"] for entry in round_overrides
     }
+    game["round_type_overrides"] = {
+        entry["round"]: entry["round_type"]
+        for entry in round_overrides
+        if "round_type" in entry
+    }
     game["round_phase_config_overrides"] = {
         entry["round"]: entry["phase_config"]
         for entry in round_overrides
@@ -38,6 +43,7 @@ def load_game_config_from_toml(config_path: pathlib.Path) -> dict:
 
     # Ensure phase_config defaults to empty dict
     game.setdefault("phase_config", {})
+    game.setdefault("round_type", "elimination")
 
     return game
 

--- a/src/agent_island/phases/elimination.py
+++ b/src/agent_island/phases/elimination.py
@@ -14,6 +14,9 @@ def phase_elimination(context: RoundContext) -> None:
     Returns:
         None
     """
+    if context.round_type == "final":
+        raise RuntimeError("phase_elimination must not run in a 'final' round")
+
     selected = context.votes.get("selected_player")
     if selected is None:
         context.logger.warning(

--- a/src/agent_island/phases/pitches.py
+++ b/src/agent_island/phases/pitches.py
@@ -13,8 +13,8 @@ def phase_pitches(context: RoundContext) -> None:
         None
     """
 
-    # The objective for the pitch depends on the round
-    if context.final_round:
+    # The objective for the pitch depends on the round type
+    if context.round_type == "final":
         outcome = "win the game"
         pitch_announcement = (
             "It is time for final pitches. "

--- a/src/agent_island/phases/votes.py
+++ b/src/agent_island/phases/votes.py
@@ -17,8 +17,8 @@ def phase_votes(context: RoundContext) -> None:
     # Initialize the vote tally
     vote_tally: dict[str, int] = {}
 
-    # The outcome for the vote depends on the round
-    if context.final_round:
+    # The outcome for the vote depends on the round type
+    if context.round_type == "final":
         outcome_verb = "wins"
         vote_instruction = "Vote for one player to win."
         voters = context.eliminated_player_ids

--- a/src/agent_island/round.py
+++ b/src/agent_island/round.py
@@ -14,6 +14,7 @@ class RoundContext:
     Args:
         round_index: The index of the round
         final_round: Whether this is the final round
+        round_type: The type of round ("elimination" or "final")
         players: List of Player objects
         active_player_ids: List of active player IDs
         eliminated_player_ids: List of eliminated player IDs
@@ -25,6 +26,7 @@ class RoundContext:
 
     round_index: int
     final_round: bool
+    round_type: str
     players: List[Player]
     active_player_ids: List[str]
     eliminated_player_ids: List[str]


### PR DESCRIPTION
## Summary

- Add `round_type` field (`"elimination"` or `"final"`) to `RoundContext` and `GameConfig`, configurable per-round via TOML `round_overrides`
- `phase_pitches` and `phase_votes` now read `context.round_type` instead of `context.final_round` to determine behavior (pitch framing, voter pool, outcome semantics)
- `phase_elimination` raises a `RuntimeError` if run in a `"final"` round
- Remove the disconnected `outcome` debug label from the engine — phases own their own logging
- Update all example configs to set `round_type = "final"` on final-round overrides

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Full game runs end-to-end with updated config (round 1 eliminates, round 2 picks winner)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)