### PR TITLE
Fix human player logging to reflect actual input

### DIFF
--- a/src/agent_island/phases/opponent_quips.py
+++ b/src/agent_island/phases/opponent_quips.py
@@ -67,12 +67,17 @@ def phase_opponent_quips(context: RoundContext) -> None:
             )
             continue
 
+        if player.config.player_type == "human":
+            prompt = action
+        else:
+            prompt = f"{system_prompt}\n\n{visible_events}\n\n{action}"
+
         for i, (target_id, quip_text) in enumerate(quips):
             context.history.add_event(
                 round_index=context.round_index,
                 heading=f"Player {player.config.player_id}'s quip about {target_id}",
                 role=f"player {player.config.player_id}",
-                prompt=f"{system_prompt}\n\n{visible_events}\n\n{action}",
+                prompt=prompt,
                 content=quip_text.strip(),
                 reasoning=response.reasoning if i == 0 else None,
                 metadata={

--- a/src/agent_island/phases/pitches.py
+++ b/src/agent_island/phases/pitches.py
@@ -69,11 +69,16 @@ def phase_pitches(context: RoundContext) -> None:
             action=action,
         )
 
+        if player.config.player_type == "human":
+            prompt = action
+        else:
+            prompt = f"{system_prompt}\n\n{visible_events}\n\n{action}"
+
         context.history.add_event(
             round_index=context.round_index,
             heading=f"Player {player.config.player_id}'s Pitch",
             role=f"player {player.config.player_id}",
-            prompt=f"{system_prompt}\n\n{visible_events}\n\n{action}",
+            prompt=prompt,
             content=response.text,
             reasoning=response.reasoning,
             metadata=response.metadata,

--- a/src/agent_island/phases/sidebars.py
+++ b/src/agent_island/phases/sidebars.py
@@ -105,14 +105,19 @@ def phase_sidebars(
             metadata = dict(response.metadata) if response.metadata else {}
             metadata["sidebar_selection"] = response.selected
 
+            if player.config.player_type == "human":
+                prompt = action
+            else:
+                prompt = (
+                    f"{system_prompt}\n\n{visible_events}"
+                    f"\n\n{action}\n\n{llm_instructions}"
+                )
+
             context.history.add_event(
                 round_index=context.round_index,
                 heading=f"Player {player_id}'s Sidebar Selection",
                 role=f"player {player_id}",
-                prompt=(
-                    f"{system_prompt}\n\n{visible_events}"
-                    f"\n\n{action}\n\n{llm_instructions}"
-                ),
+                prompt=prompt,
                 content=response.text,
                 reasoning=response.reasoning,
                 metadata=metadata or None,
@@ -209,6 +214,11 @@ def _run_sidebar(
             action=action,
         )
 
+        if player.config.player_type == "human":
+            prompt = action
+        else:
+            prompt = f"{system_prompt}\n\n{visible_events}\n\n{action}"
+
         context.history.add_event(
             round_index=context.round_index,
             heading=(
@@ -216,7 +226,7 @@ def _run_sidebar(
                 f"Player {speaker_id}'s message"
             ),
             role=f"player {speaker_id}",
-            prompt=(f"{system_prompt}\n\n{visible_events}\n\n{action}"),
+            prompt=prompt,
             content=response.text,
             reasoning=response.reasoning,
             metadata=response.metadata,

--- a/src/agent_island/phases/votes.py
+++ b/src/agent_island/phases/votes.py
@@ -107,11 +107,18 @@ Here, we assume X and Y are player IDs."""
         metadata = dict(response.metadata) if response.metadata else {}
         metadata["vote"] = response.selected
 
+        if player.config.player_type == "human":
+            prompt = action
+        else:
+            prompt = (
+                f"{system_prompt}\n\n{visible_events}\n\n{action}\n\n{llm_instructions}"
+            )
+
         context.history.add_event(
             round_index=context.round_index,
             heading=f"Player {player.config.player_id}'s Vote",
             role=f"player {player.config.player_id}",
-            prompt=f"{system_prompt}\n\n{visible_events}\n\n{action}\n\n{llm_instructions}",
+            prompt=prompt,
             content=response.text,
             reasoning=response.reasoning,
             metadata=metadata or None,


### PR DESCRIPTION
## Summary

- For human players, the logged `prompt` field now contains only the `action` text (what the CLI collector actually displays), instead of the full AI prompt with `system_prompt`, `visible_events`, and `llm_instructions` that the human never sees
- Applied consistently across all phases: pitches, votes, sidebars (both selection and messages), and opponent quips

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] Run a game with a human player and verify the logged prompt in the JSON output matches what the human saw

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)