### PR TITLE
Log model on failed API request

### DIFF
--- a/src/agent_island/player.py
+++ b/src/agent_island/player.py
@@ -151,9 +151,10 @@ class AIPlayer(Player):
                 if attempt < self.max_retries:
                     wait = 2**attempt  # 1s, 2s, 4s
                     logger.warning(
-                        "Request failed for player %s (attempt %d/%d): %s. "
-                        "Retrying in %ds.",
+                        "Request failed for player %s (model %s) "
+                        "(attempt %d/%d): %s. Retrying in %ds.",
                         self.config.player_id,
+                        self.config.model,
                         attempt + 1,
                         self.max_retries + 1,
                         exc,
@@ -162,12 +163,18 @@ class AIPlayer(Player):
                     time.sleep(wait)
                 else:
                     logger.error(
-                        "Request failed for player %s after %d attempt(s): %s",
+                        "Request failed for player %s (model %s) "
+                        "after %d attempt(s): %s",
                         self.config.player_id,
+                        self.config.model,
                         self.max_retries + 1,
                         exc,
                     )
-        raise last_exc  # type: ignore[misc]
+        raise RuntimeError(
+            f"Request failed for player {self.config.player_id} "
+            f"(model {self.config.model}) after {self.max_retries + 1} "
+            f"attempt(s): {last_exc}"
+        ) from last_exc
 
     def _extract_choice(
         self, content: str, valid_player_ids: list[str]


### PR DESCRIPTION
## Summary
- Include model name in warning/error log messages during request retries and final failure
- Wrap the re-raised exception in a `RuntimeError` with model info so it appears in the JSON game log's `game.error` field

Closes #123

## Test plan
- [x] Verified module imports cleanly
- [x] Verified failed request logs model in console warning/error messages
- [x] Verified RuntimeError includes model name (appears in JSON game log's `game.error` field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)