### PR TITLE
Add timestamp to events in game history

### DIFF
--- a/src/agent_island/history.py
+++ b/src/agent_island/history.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List
 
 
@@ -26,6 +27,7 @@ class Event:
     active_visibility: List[str]
     reasoning: str | None = None
     metadata: Dict[str, Any] | None = None
+    timestamp: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -37,6 +39,7 @@ class Event:
             "active_visibility": self.active_visibility,
             "reasoning": self.reasoning,
             "metadata": self.metadata,
+            "timestamp": self.timestamp,
         }
 
 
@@ -153,6 +156,7 @@ class History:
             active_visibility=active_visibility,
             reasoning=reasoning,
             metadata=metadata,
+            timestamp=datetime.now(timezone.utc).isoformat(),
         )
         self.rounds[round_index].events.append(event)
         if self.on_event:


### PR DESCRIPTION
## Summary
- Add a `timestamp` field to `Event` dataclass, auto-populated with UTC ISO-8601 when events are added to history
- Include timestamp in `to_dict()` output so it appears in JSON game logs

Closes #125

## Test plan
- [x] Verified module imports cleanly
- [x] Unit tested that `add_event` populates timestamp and `to_dict()` includes it
- [x] Ran a full 3-player, 2-round game — all 18 events have timestamps in the JSON log

🤖 Generated with [Claude Code](https://claude.com/claude-code)