### PR TITLE
Drop 'briefly' from summarization strategy prompt

### DIFF
--- a/src/agent_island/memory.py
+++ b/src/agent_island/memory.py
@@ -102,7 +102,7 @@ class SummarizationStrategy(MemoryStrategy):
             visible_events = f"{memory_context}\n\n{visible_events}"
 
         action = (
-            "Please briefly summarize the events of this round. "
+            "Please summarize the events of this round. "
             "This summary will be the only context on the events of this round "
             "that you will have in future rounds. "
             "Other players will not be able to see your summary."


### PR DESCRIPTION
## Summary
- Removes "briefly" from the summarization strategy prompt to avoid biasing toward overly terse summaries

Closes #127

## Test plan
- [x] Run a game with the summarization memory strategy and verify summaries are generated without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)