### PR TITLE
Add game-local random seed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Alternatively, install the CLI globally with `uv tool install .` and run `agent-
 
 **Prerequisite:** `OPENROUTER_API_KEY` must be set in your environment or a `.env` file.
 
+Game configuration may set `game_id` for a stable log identity and
+`random_seed` for reproducible speaking order and tie-breaks. If `random_seed`
+is omitted, `game_id` remains the seed for backward compatibility. Separate
+values let multiple games share matched random conditions without duplicate log
+IDs.
+
 ## Development
 
 ### Linting

--- a/src/agent_island/cli.py
+++ b/src/agent_island/cli.py
@@ -90,6 +90,7 @@ def main() -> None:
         round_phase_config_overrides=game_data.get("round_phase_config_overrides", {}),
         log_prefix=game_data.get("log_prefix", "gameplay"),
         game_id=game_data.get("game_id"),
+        random_seed=game_data.get("random_seed"),
     )
 
     human_ids = {p.config.player_id for p in players if p.config.player_type == "human"}

--- a/src/agent_island/engine.py
+++ b/src/agent_island/engine.py
@@ -31,7 +31,9 @@ class GameConfig:
         phase_config: Default per-phase config keyed by phase name
         round_phase_config_overrides: Per-round phase config overrides
         log_prefix: Optional prefix for log filenames (default: "gameplay")
-        game_id: Optional game ID for reproducibility
+        game_id: Optional unique game ID used for logs and, by default, randomness
+        random_seed: Optional game-local random seed. When omitted, game_id is used
+            for backward compatibility.
     """
 
     num_players: int
@@ -48,6 +50,7 @@ class GameConfig:
     )
     log_prefix: str = field(default="gameplay")
     game_id: str | None = field(default=None)
+    random_seed: int | str | None = field(default=None)
 
 
 class GameEngine:
@@ -70,6 +73,7 @@ class GameEngine:
         self.logger = logging.getLogger(__name__)
         self._validate_config()
         self.history = History(on_event=on_event)
+        self.rng = random.Random()
 
     def _validate_config(self) -> None:
         """Validate game config against player configs and phase registry."""
@@ -195,6 +199,7 @@ class GameEngine:
             logger=self.logger,
             history=self.history,
             rules_prompt=self.game_config.rules_prompt,
+            rng=self.rng,
         )
 
     def play(self) -> str | None:
@@ -211,8 +216,13 @@ class GameEngine:
         game_id = self.game_config.game_id or str(uuid.uuid4())
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-        # Seed random draws from the game ID for partial reproducibility
-        random.seed(game_id)
+        # Preserve legacy behavior unless callers separate identity from randomness.
+        random_seed = (
+            self.game_config.random_seed
+            if self.game_config.random_seed is not None
+            else game_id
+        )
+        self.rng.seed(random_seed)
 
         # Log start of game
         self.logger.info(f"Starting game {game_id} ({timestamp})")
@@ -384,6 +394,11 @@ class GameEngine:
             output = {
                 "game": {
                     "id": game_id,
+                    "random_seed": (
+                        self.game_config.random_seed
+                        if self.game_config.random_seed is not None
+                        else game_id
+                    ),
                     "timestamp": timestamp,
                     "num_players": self.game_config.num_players,
                     "num_rounds": self.game_config.num_rounds,

--- a/src/agent_island/phases/common.py
+++ b/src/agent_island/phases/common.py
@@ -1,7 +1,9 @@
 import random
 
 
-def permute_player_ids(player_ids: list[str]) -> list[str]:
+def permute_player_ids(
+    player_ids: list[str], rng: random.Random | None = None
+) -> list[str]:
     """
     Permute the player IDs in a random order.
 
@@ -11,4 +13,5 @@ def permute_player_ids(player_ids: list[str]) -> list[str]:
     Returns:
         list[str]: The permuted player IDs
     """
-    return random.sample(player_ids, k=len(player_ids))
+    generator = rng if rng is not None else random
+    return generator.sample(player_ids, k=len(player_ids))

--- a/src/agent_island/phases/consolidate_memory.py
+++ b/src/agent_island/phases/consolidate_memory.py
@@ -18,7 +18,7 @@ def phase_consolidate_memory(context: RoundContext) -> None:
     """
     all_player_ids = context.active_player_ids + context.eliminated_player_ids
 
-    for player_id in permute_player_ids(all_player_ids):
+    for player_id in permute_player_ids(all_player_ids, context.rng):
         player = next(
             player for player in context.players if player.config.player_id == player_id
         )

--- a/src/agent_island/phases/opponent_quips.py
+++ b/src/agent_island/phases/opponent_quips.py
@@ -14,7 +14,7 @@ def phase_opponent_quips(context: RoundContext) -> None:
     play style. One event is emitted per quip for easy downstream filtering.
     """
 
-    for player_id in permute_player_ids(context.history.player_ids):
+    for player_id in permute_player_ids(context.history.player_ids, context.rng):
         player = next(
             player for player in context.players if player.config.player_id == player_id
         )

--- a/src/agent_island/phases/pitches.py
+++ b/src/agent_island/phases/pitches.py
@@ -37,7 +37,7 @@ def phase_pitches(context: RoundContext) -> None:
     )
 
     # Permute the player IDs to avoid order effects
-    for player_id in permute_player_ids(context.active_player_ids):
+    for player_id in permute_player_ids(context.active_player_ids, context.rng):
         # Get the player object from the player ID
         player = next(
             player for player in context.players if player.config.player_id == player_id

--- a/src/agent_island/phases/sidebars.py
+++ b/src/agent_island/phases/sidebars.py
@@ -56,10 +56,12 @@ def phase_sidebars(
     )
 
     for exchange in range(num_exchanges):
-        for player_id in permute_player_ids(active):
+        for player_id in permute_player_ids(active, context.rng):
             player = next(p for p in context.players if p.config.player_id == player_id)
 
-            candidates = permute_player_ids([pid for pid in active if pid != player_id])
+            candidates = permute_player_ids(
+                [pid for pid in active if pid != player_id], context.rng
+            )
 
             memory_context = player.memory.render()
             visible_events = context.history.render_for_player(player_id)

--- a/src/agent_island/phases/votes.py
+++ b/src/agent_island/phases/votes.py
@@ -1,5 +1,3 @@
-import random
-
 from ..round import RoundContext
 from .common import permute_player_ids
 
@@ -50,7 +48,7 @@ def phase_votes(context: RoundContext) -> None:
     candidates = context.active_player_ids
 
     # Permute the player IDs to avoid order effects
-    for voter in permute_player_ids(voters):
+    for voter in permute_player_ids(voters, context.rng):
         # Get the player object from the voter ID
         player = next(
             player for player in context.players if player.config.player_id == voter
@@ -65,7 +63,9 @@ def phase_votes(context: RoundContext) -> None:
 
         # Permute candidates at the voter level to avoid order effects
         # Exclude the active voter from the candidates
-        candidates_for_voter = permute_player_ids([c for c in candidates if c != voter])
+        candidates_for_voter = permute_player_ids(
+            [c for c in candidates if c != voter], context.rng
+        )
 
         action = (
             f"{vote_instruction} You cannot vote for yourself. "
@@ -142,7 +142,7 @@ Here, we assume X and Y are player IDs."""
     # Find selected player
     if not vote_tally:
         # If no valid votes, randomly select a player
-        selected_player_id = random.choice(candidates)
+        selected_player_id = context.rng.choice(candidates)
         context.logger.info(
             f"No valid votes found. Randomly selecting Player {selected_player_id}"
         )
@@ -184,7 +184,7 @@ Here, we assume X and Y are player IDs."""
 
         # If there is a tie, randomly select a player from the tied players
         else:
-            selected_player_id = random.choice(tied_players)
+            selected_player_id = context.rng.choice(tied_players)
             context.logger.info(
                 f"Tie between {tied_players} with "
                 f"{max_votes} vote(s). Randomly selecting "

--- a/src/agent_island/round.py
+++ b/src/agent_island/round.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from dataclasses import dataclass, field
 from typing import Any, Callable, List
 
@@ -21,6 +22,7 @@ class RoundContext:
         logger: Logger for the round
         history: History for the round
         rules_prompt: Prompt with the rules of the game
+        rng: Game-local random number generator
         votes: Dictionary of votes for the round
     """
 
@@ -33,6 +35,7 @@ class RoundContext:
     logger: logging.Logger
     history: History
     rules_prompt: str
+    rng: random.Random = field(default_factory=random.Random)
     votes: dict[str, Any] = field(default_factory=dict)
 
 

--- a/tests/test_engine_random_seed.py
+++ b/tests/test_engine_random_seed.py
@@ -1,0 +1,72 @@
+"""Tests for game identity and random-seed separation."""
+
+import random
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent_island import GameConfig, GameEngine, PlayerConfig
+from agent_island.phases import PHASE_REGISTRY
+
+
+def _player(player_id: str):
+    return SimpleNamespace(
+        config=PlayerConfig(
+            player_id=player_id,
+            character_prompt=f"You are {player_id}.",
+        )
+    )
+
+
+def _config(*, game_id: str, random_seed: int | None = None) -> GameConfig:
+    return GameConfig(
+        num_players=2,
+        num_rounds=1,
+        phases=["capture_randomness"],
+        rules_prompt="Rules",
+        game_id=game_id,
+        random_seed=random_seed,
+    )
+
+
+class GameRandomSeedTest(unittest.TestCase):
+    def test_explicit_seed_is_independent_from_game_id(self) -> None:
+        players = [_player("AAAA"), _player("BBBB")]
+        draws: list[tuple[float, list[str]]] = []
+
+        def capture_randomness(context):
+            draws.append(
+                (
+                    context.rng.random(),
+                    context.rng.sample(context.active_player_ids, k=2),
+                )
+            )
+
+        global_state = random.getstate()
+        with patch.dict(PHASE_REGISTRY, {"capture_randomness": capture_randomness}):
+            GameEngine(
+                _config(game_id="unique-game-a", random_seed=123), players
+            ).play()
+            GameEngine(
+                _config(game_id="unique-game-b", random_seed=123), players
+            ).play()
+
+        self.assertEqual(draws[0], draws[1])
+        self.assertEqual(random.getstate(), global_state)
+
+    def test_game_id_remains_the_default_seed(self) -> None:
+        players = [_player("AAAA"), _player("BBBB")]
+        draws: list[float] = []
+
+        def capture_randomness(context):
+            draws.append(context.rng.random())
+
+        with patch.dict(PHASE_REGISTRY, {"capture_randomness": capture_randomness}):
+            GameEngine(_config(game_id="legacy-game"), players).play()
+
+        expected = random.Random("legacy-game").random()
+        self.assertEqual(draws, [expected])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an optional `GameConfig.random_seed` separate from the unique `game_id`
- give each game engine its own `random.Random` instance and route speaking-order
  and tie-break draws through it
- preserve the legacy behavior of using `game_id` as the seed when
  `random_seed` is omitted
- record the effective seed in game logs and accept it through TOML/CLI config
- test that distinct game IDs with the same seed get matched randomness without
  mutating process-global RNG state

This unblocks paired experiments that need unique log identities but identical
initial random conditions.

## Testing

- `uv run python -m unittest discover -s tests`
- `uvx ruff check .`
- `uvx ruff format --check .`
- `git diff --check`

No closing issue: this extends the partial reproducibility work from closed
issue #27 with an independently configurable, game-local RNG.
